### PR TITLE
Add package Rmfrac

### DIFF
--- a/Econometrics.md
+++ b/Econometrics.md
@@ -354,6 +354,7 @@ overlap.
   - `r pkg("dlsem")` - Distributed-lag linear structural equation models.
   - `r pkg("lpirfs")` - Local projections impulse response functions.
   - `r pkg("apt")` - Asymmetric price transmission models.
+  - `r pkg("Rmfrac")` - Simulation and analyses of fractional and multifractional processes.
 
 
 ### Data sets


### PR DESCRIPTION
Hi @zeileis 

This adds the package [Rmfrac](https://cran.r-project.org/package=Rmfrac) to the Time series data and models - Miscellaneous: section of the task view. 

The package provides tools for simulation of fractional and multifractional processes; estimation of the Hurst function, local fractal dimension, and related geometric statistics; and Hurst function based clustering of time series.
I am the maintainer of this package.

Feel free to edit or move to an appropriate location.

Thanks.

